### PR TITLE
Add wget to our tinyproxy docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
     tinyproxy \
+    wget \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 


### PR DESCRIPTION
To get environment variables into our containers running on ECS we use
wget to download aws-env from https://github.com/Droplr/aws-env/releases  and then run it.
Therefore our image needs wget installed.