### PR TITLE
Add ca-certificates to our docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     tinyproxy \
     wget \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 


### PR DESCRIPTION
To download a binary from github we need to trust github's certificate.
To do this we need to install the ca certs provided by ubuntu.